### PR TITLE
mixcr arguments fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ To run the pipeline on your own data, you need to have TCRalpha and TCRbeta repe
 
 We use the following mixcr pipeline for each well: 
 ```bash
-$MIXCR analyze generic-amplicon --species hsa --rna \
+$MIXCR analyze generic-tcr-amplicon --species hsa --rna \
 --tag-pattern "^N{0:1}(SAMPLE:N{7})(R1:*)\^(R2:*)" \
 --floating-left-alignment-boundary \
 --floating-right-alignment-boundary C \
 --split-by-sample \
---sample-sheet plate_index.tsv \
+--sample-table plate_index.tsv \
 ${fp}_L{{n}}_R1.fastq.gz ${fp}_L{{n}}_R2.fastq.gz \
 $OUTDIR/${sample} \
 --use-local-temp

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ To run the pipeline on your own data, you need to have TCRalpha and TCRbeta repe
 
 We use the following mixcr pipeline for each well: 
 ```bash
-$MIXCR analyze generic-tcr-amplicon --species hsa --rna \
+$MIXCR analyze generic-amplicon --species hsa --rna \
 --tag-pattern "^N{0:1}(SAMPLE:N{7})(R1:*)\^(R2:*)" \
 --floating-left-alignment-boundary \
 --floating-right-alignment-boundary C \


### PR DESCRIPTION
Looks like there might have been some aliases in the mixcr script that is in the README, thought this might help other users: 

```bash
$MIXCR analyze generic-tcr-amplicon --species hsa --rna \ #Change from just generic-amplicon
--tag-pattern "^N{0:1}(SAMPLE:N{7})(R1:*)\^(R2:*)" \
--floating-left-alignment-boundary \
--floating-right-alignment-boundary C \
--split-by-sample \
--sample-table plate_index.tsv \ #Change from just generic-amplicon #Change from sample-sheet
${fp}_L{{n}}_R1.fastq.gz ${fp}_L{{n}}_R2.fastq.gz \
$OUTDIR/${sample} \
--use-local-temp
```